### PR TITLE
Persist to Dataset as parquet instead of sqlite

### DIFF
--- a/trackio/commit_scheduler.py
+++ b/trackio/commit_scheduler.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from io import SEEK_END, SEEK_SET, BytesIO
 from pathlib import Path
 from threading import Lock, Thread
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 from huggingface_hub.hf_api import (
     DEFAULT_IGNORE_PATTERNS,
@@ -68,6 +68,8 @@ class CommitScheduler:
             useful to avoid degraded performances on the repo when it grows too large.
         hf_api (`HfApi`, *optional*):
             The [`HfApi`] client to use to commit to the Hub. Can be set with custom settings (user agent, token,...).
+        on_before_commit (`Callable[[], None]`, *optional*):
+            If specified, a function that will be called before the CommitScheduler lists files to create a commit.
 
     Example:
     ```py
@@ -118,8 +120,10 @@ class CommitScheduler:
         ignore_patterns: Optional[Union[List[str], str]] = None,
         squash_history: bool = False,
         hf_api: Optional["HfApi"] = None,
+        on_before_commit: Optional[Callable[[], None]] = None,
     ) -> None:
         self.api = hf_api or HfApi(token=token)
+        self.on_before_commit = on_before_commit
 
         # Folder
         self.folder_path = Path(folder_path).expanduser().resolve()
@@ -239,6 +243,9 @@ class CommitScheduler:
         """
         # Check files to upload (with lock)
         with self.lock:
+            if self.on_before_commit is not None:
+                self.on_before_commit()
+
             logger.debug("Listing files to upload for scheduled commit.")
 
             # List files from folder (taken from `_prepare_upload_folder_additions`)

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from threading import Lock
 
+import pandas as pd
 from huggingface_hub import hf_hub_download
 from huggingface_hub.errors import EntryNotFoundError
 
@@ -55,7 +56,7 @@ class SQLiteStorage:
         """
         db_path = SQLiteStorage.get_project_db_path(project)
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        with SQLiteStorage.get_scheduler().lock:
+        with SQLiteStorage.get_scheduler(project).lock:
             dataset_id = os.environ.get("TRACKIO_DATASET_ID")
             if dataset_id is not None and not SQLiteStorage._dataset_import_attempted:
                 filename = SQLiteStorage.get_project_db_filename(project)
@@ -89,7 +90,22 @@ class SQLiteStorage:
         return db_path
 
     @staticmethod
-    def get_scheduler():
+    def export_as_parquet(project):
+        """
+        Exports the project DB file as Parquet under the same path but with extension ".parquet".
+        """
+
+        def _export():
+            db_path = SQLiteStorage.get_project_db_path(project)
+            parquet_path = db_path.with_suffix(".parquet")
+            with sqlite3.connect(db_path) as conn:
+                df = pd.read_sql("SELECT * from metrics", conn)
+                df.to_parquet(parquet_path)
+
+        return _export
+
+    @staticmethod
+    def get_scheduler(project):
         """
         Get the scheduler for the database based on the environment variables.
         This applies to both local and Spaces.
@@ -107,8 +123,10 @@ class SQLiteStorage:
                     repo_type="dataset",
                     folder_path=TRACKIO_DIR,
                     private=True,
+                    allow_patterns="*.parquet",
                     squash_history=True,
                     token=hf_token,
+                    on_before_commit=SQLiteStorage.export_as_parquet(project),
                 )
             SQLiteStorage._current_scheduler = scheduler
             return scheduler
@@ -122,7 +140,7 @@ class SQLiteStorage:
         """
         db_path = SQLiteStorage.init_db(project)
 
-        with SQLiteStorage.get_scheduler().lock:
+        with SQLiteStorage.get_scheduler(project).lock:
             with SQLiteStorage._get_connection(db_path) as conn:
                 cursor = conn.cursor()
 
@@ -178,7 +196,7 @@ class SQLiteStorage:
             )
 
         db_path = SQLiteStorage.init_db(project)
-        with SQLiteStorage.get_scheduler().lock:
+        with SQLiteStorage.get_scheduler(project).lock:
             with SQLiteStorage._get_connection(db_path) as conn:
                 cursor = conn.cursor()
 


### PR DESCRIPTION
* Add on_before_commit to CommitScheduler
* Implement SQLite -> Parquet using Pandas as the go-between
* Pass project into get_scheduler so we know which project file to open at export time